### PR TITLE
Clean up unused variables and streamline HID handling

### DIFF
--- a/XHC HB04_Claude V3/Core/Inc/encoder_cubeide.h
+++ b/XHC HB04_Claude V3/Core/Inc/encoder_cubeide.h
@@ -7,16 +7,9 @@
 
 #include <stdint.h>
 
-extern uint16_t enc_prev_cnt;
-extern int32_t enc_rem;
-extern volatile int16_t encoder_1ms_buffer;
-extern volatile int32_t impulse_buffer;
-
 /* Funktionsprototypen */
 void encoder_init(void);
 int16_t encoder_read(void);
-uint8_t encoder_has_activity(void);
-void encoder_reset(void);
 void encoder_display_test(void);
 void encoder_display_sent_values(void);
 void encoder_1ms_poll(void);

--- a/XHC HB04_Claude V3/Core/Src/button_matrix.c
+++ b/XHC HB04_Claude V3/Core/Src/button_matrix.c
@@ -5,7 +5,6 @@
 
 #include "main.h"
 #include "button_matrix.h"
-#include "stdio.h"
 #include "user_defines.h"
 
 /* Button-Matrix Hardware-Konfiguration */

--- a/XHC HB04_Claude V3/Core/Src/rotary_switch.c
+++ b/XHC HB04_Claude V3/Core/Src/rotary_switch.c
@@ -25,7 +25,6 @@ void rotary_switch_init(void)
 
 uint8_t rotary_switch_read(void)
 {
-    static uint8_t last_position = ROTARY_OFF;
     static uint32_t off_start_time = 0;
     static uint8_t stable_position = ROTARY_OFF;
 
@@ -66,7 +65,6 @@ uint8_t rotary_switch_read(void)
         stable_position = ROTARY_OFF;
     }
 
-    last_position = stable_position;
     return stable_position;
 }
 

--- a/XHC HB04_Claude V3/Core/Src/xhc_recieve.c
+++ b/XHC HB04_Claude V3/Core/Src/xhc_recieve.c
@@ -5,8 +5,6 @@
 
 #include "XHC_DataStructures.h"
 #include <string.h>
-#include "st7735_dma.h"
-#include <stdio.h>
 #include "xhc_display_ui.h"
 #include "rotary_switch.h"
 
@@ -87,7 +85,6 @@ void xhc_process_received_data(void)
 
     // Timing
     static uint32_t last_coord_ts  = 0;
-    static uint32_t last_status_ts = 0;
     static uint8_t  settling_mode  = 1;   // anfänglich empfindlicher
     static uint16_t updates_since_settle = 0;
 
@@ -137,8 +134,6 @@ void xhc_process_received_data(void)
 
     if (status_changed) {
         xhc_ui_update_status_bar(rotary, step);
-        last_status_ts = now;
-
         // Caches erst NACH erfolgreichem Draw updaten
         last_feed      = feed;
         last_feed_ovr  = feed_ovr;


### PR DESCRIPTION
## Summary
- remove unused globals and debug scaffolding from the XHC main loop while keeping button/encoder handling focused on active signals
- drop unused encoder globals/functions, normalize the 1ms poll helper, and include the required headers explicitly
- prune unused includes and variables from the receive, rotary switch, and button matrix modules

## Testing
- not run (embedded target)


------
https://chatgpt.com/codex/tasks/task_e_68df6be1cdb483338231dd098a2063a3